### PR TITLE
Change the name of argument in repeat function to resolve problem optimizing

### DIFF
--- a/jlinq.js
+++ b/jlinq.js
@@ -214,23 +214,23 @@ var jl;
                     
                     //repeats the previous command with new
                     //arguments
-                    repeat:function(arguments) {
+                    repeat:function(args) {
                     
                         //check if there is anything to repeat
-                        if (!self.instance.lastCommand || arguments == null) { return; }
+                        if (!self.instance.lastCommand || args == null) { return; }
                         
                         //get the array of arguments to work with
-                        arguments = framework.util.toArray(arguments);
+                        args = framework.util.toArray(args);
                             
                         //check if there is a field name has changed, and
                         //if so, update the arguments to match
-                        if (self.canRepeatCommand(arguments)) {
-                            self.instance.lastField = arguments[0];
-                            arguments = framework.util.select(arguments, null, 1, null);
+                        if (self.canRepeatCommand(args)) {
+                            self.instance.lastField = args[0];
+                            args = framework.util.select(args, null, 1, null);
                         }
                         
                         //invoke the command now
-                        self.queue(self.instance.lastCommand, arguments);
+                        self.queue(self.instance.lastCommand, args);
                     },
                     
                     //saves a command to evaluate later


### PR DESCRIPTION
Change the name of an argument from 'arguments' to 'args'
